### PR TITLE
fix compatibility check for 20 R10

### DIFF
--- a/Project/Sources/Methods/StartUp.4dm
+++ b/Project/Sources/Methods/StartUp.4dm
@@ -2,24 +2,24 @@
 
 
 
-  // Check minimal version of 4D for compatibility
+// Check minimal version of 4D for compatibility
 C_TEXT:C284(compatibility_version_check)
 C_BOOLEAN:C305($fl_Select)
 $compatibility_version_check:=Application version:C493
-If (Num:C11($compatibility_version_check)<1740)
-	  // (Content of this message should be included as an xliff resource):
+If ($compatibility_version_check<"1740")
+	// (Content of this message should be included as an xliff resource):
 	
-	CONFIRM:C162(Util_Get_LocalizedMessage ("VersionCheck"))
+	CONFIRM:C162(Util_Get_LocalizedMessage("VersionCheck"))
 	If (OK=1)
 		QUIT 4D:C291
 	End if 
 End if 
 If (Not:C34(Version type:C495 ?? 64 bit version:K5:25))
-	ALERT:C41(Util_Get_LocalizedMessage ("Use64bitVersion"))  // to avoid an empty Admin dashboard.
+	ALERT:C41(Util_Get_LocalizedMessage("Use64bitVersion"))  // to avoid an empty Admin dashboard.
 End if 
 
 If ((Application type:C494=4D Local mode:K5:1) | (Application type:C494=4D Remote mode:K5:5))
-	CALL WORKER:C1389("Generic";"W_Generic";"StartupScreen";$fl_Select)
+	CALL WORKER:C1389("Generic"; "W_Generic"; "StartupScreen"; $fl_Select)
 	
 End if 
 


### PR DESCRIPTION
method startup checks for compatibility to be > 1740.
It does so by using num(version), which fails for 20A10 (returning 0)
This change compares strings, instead of numbers, as "20A10" is larger than "1740," while "1740" is larger than "1610".